### PR TITLE
subnet removed and changed source

### DIFF
--- a/_example/example.tf
+++ b/_example/example.tf
@@ -15,8 +15,8 @@ module "resource_group" {
 
 #Vnet
 module "vnet" {
-  source  = "clouddrove/virtual-network/azure"
-  version = "1.0.1"
+  source  = "clouddrove/vnet/azure"
+  version = "1.0.0"
 
   name        = "app"
   environment = "example"
@@ -26,18 +26,12 @@ module "vnet" {
   location            = module.resource_group.resource_group_location
   address_space       = "10.0.0.0/16"
   enable_ddos_pp      = false
-
-  #subnet
-  subnet_names                  = ["subnet1"]
-  subnet_prefixes               = ["10.0.1.0/24"]
-  disable_bgp_route_propagation = false
-
 }
 
 #Vnet
 module "vnet_remote" {
-  source  = "clouddrove/virtual-network/azure"
-  version = "1.0.1"
+  source  = "clouddrove/vnet/azure"
+  version = "1.0.0"
 
   name        = "remote"
   environment = "example"
@@ -47,12 +41,6 @@ module "vnet_remote" {
   location            = module.resource_group.resource_group_location
   address_space       = "20.0.0.0/16"
   enable_ddos_pp      = false
-
-  #subnet
-  subnet_names                  = ["subnet1"]
-  subnet_prefixes               = ["20.0.1.0/24"]
-  disable_bgp_route_propagation = false
-
 }
 
 module "vnet_peering" {


### PR DESCRIPTION
## what
* Removed subnet block from vnet resource and vnet_remote block.
* Changed the source and version of vnet and vnet_remote module (clouddrove/virtual-network/azure to clouddrove/vnet/azure).


## why
* We are going to remove clouddrove/virtual-network/azure module, so there is changes to get error.
* We have separate modules to include a subnet in the resource so there is no need to use a subnet block in vnet resource block.
* Removed subnet block because it was giving an error while using clouddrove/vnet/azure source in vnet resource block.


## references
* Took source and version information from clouddrove's official github page
